### PR TITLE
Save singleplayer data to the world's folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          17,    # Current Java LTS & minimum supported by Minecraft
+          21,    # Current Java LTS & minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
         os: [ubuntu-20.04, windows-2022]
@@ -32,7 +32,7 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
+        if: ${{ runner.os == 'Linux' && matrix.java == '21' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v2
         with:
           name: Artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ classes/
 .settings/
 .vscode/
 bin/
+.factorypath
 .classpath
 .project
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -43,8 +43,8 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-	it.options.release = 17
+	// Minecraft 1.20.5 upwards uses Java 21.
+	it.options.release = 21
 }
 
 java {

--- a/src/main/java/com/nettakrim/spyglass_astronomy/SpaceDataManager.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/SpaceDataManager.java
@@ -28,8 +28,8 @@ public class SpaceDataManager {
     private long planetSeed;
     private float yearLength;
 
-    private File data = null;
-    private Path storagePath;
+    private final File data;
+    private final Path storagePath;
     private final String fileName;
 
     public ArrayList<StarData> starDatas;
@@ -45,11 +45,9 @@ public class SpaceDataManager {
 
         fileName = storagePath +"/"+seedHash + ".txt";
 
-        if (Files.exists(storagePath)) {
-            data = new File(fileName);
-            if (data.exists()) {
-                useDefault = !loadData();
-            }
+        data = new File(fileName);
+        if (data.exists()) {
+            useDefault = !loadData();
         }
 
         if (useDefault) {
@@ -149,9 +147,8 @@ public class SpaceDataManager {
     public void saveData() {
         if (changesMade == 0) return;
         try {
-            if (data == null) {
+            if (!data.exists()) {
                 Files.createDirectories(storagePath);
-                data = new File(fileName);
             }
             FileWriter writer = new FileWriter(data);
             StringBuilder s = new StringBuilder("Spyglass Astronomy - Format: "+SAVE_FORMAT);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
     "fabricloader": ">=0.14.21",
     "fabric": "*",
     "minecraft": ">=1.21.0",
-    "java": ">=17"
+    "java": ">=21"
   },
   "suggests": {
     "another-mod": "*"

--- a/src/main/resources/spyglass_astronomy.mixins.json
+++ b/src/main/resources/spyglass_astronomy.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.nettakrim.spyglass_astronomy.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],
   "client": [


### PR DESCRIPTION
Currently, astronomy data are saved near the root of the `.minecraft` folder. That makes sense for multiplayer data, but that's bothering me for singleplayer. The link between the data and the worlds is pretty brittle; it can be broken by simply renaming the world, and multiple worlds with the same name end up being linked to the same data.
I like to keep tidy backups of my worlds, and it's much easier when all of a world's data is located in one place, and each world is clearly separated from the other.

This PR makes it so data for singleplayer worlds will be saved into the world's folder, under `data/spyglass_astronomy/*.txt`.
This also includes a migration process, so people who upgrade from an older version of the mod will not loose their data.