### PR TITLE
Fix GPU buffer memory getting leaked

### DIFF
--- a/src/main/java/com/nettakrim/spyglass_astronomy/SpaceRenderingManager.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/SpaceRenderingManager.java
@@ -183,6 +183,9 @@ public class SpaceRenderingManager {
         }
 
         BuiltBuffer builtBuffer = bufferBuilder.end();
+        if (constellationsBuffer != null) {
+            constellationsBuffer.close();
+        }
         constellationsBuffer = RenderSystem.getDevice().createBuffer(() -> "SGA Constellations Buffer", 40, builtBuffer.getBuffer());
         constellationsCount = builtBuffer.getDrawParameters().indexCount();
         builtBuffer.close();
@@ -201,6 +204,9 @@ public class SpaceRenderingManager {
             star.setVertices(bufferBuilder);
         }
 
+        if (starsBuffer != null) {
+            starsBuffer.close();
+        }
         BuiltBuffer builtBuffer = bufferBuilder.end();
         starsBuffer = RenderSystem.getDevice().createBuffer(() -> "SGA Stars Buffer", 40, builtBuffer.getBuffer());
         starsCount = builtBuffer.getDrawParameters().indexCount();
@@ -228,6 +234,9 @@ public class SpaceRenderingManager {
         }
 
         BuiltBuffer builtBuffer = bufferBuilder.end();
+        if (planetsBuffer != null) {
+            planetsBuffer.close();
+        }
         planetsBuffer = RenderSystem.getDevice().createBuffer(() -> "SGA Planets Buffer", 40, builtBuffer.getBuffer());
         planetsCount = builtBuffer.getDrawParameters().indexCount();
         builtBuffer.close();
@@ -239,6 +248,9 @@ public class SpaceRenderingManager {
         SpyglassAstronomyClient.drawingConstellation.setVertices(bufferBuilder, true);
 
         BuiltBuffer builtBuffer = bufferBuilder.end();
+        if (drawingBuffer != null) {
+            drawingBuffer.close();
+        }
         drawingBuffer = RenderSystem.getDevice().createBuffer(() -> "SGA Drawing Buffer", 40, builtBuffer.getBuffer());
         drawingCount = builtBuffer.getDrawParameters().indexCount();
         builtBuffer.close();


### PR DESCRIPTION
Under Linux (Arch & Debian 13 confirmed), memory is slowly being leaked, resulting in Minecraft taking up all memory (in my case 16GB) over a couple of hours of playtime. Depending on the System, this would result in the game crashing or in severe lagspikes due to the java garbage collector having to sift through gigabytes of data.

This PR makes sure that the GPU buffers are closed before being overwritten, fixing the memory leak (confirmed on the two systems mentioned previously). I have not been able to test this on a Mac or a Windows PC but do not see why it would not work.