### PR TITLE
Add Iris support

### DIFF
--- a/src/main/java/com/nettakrim/spyglass_astronomy/SpaceRenderingManager.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/SpaceRenderingManager.java
@@ -7,6 +7,7 @@ import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -26,6 +27,7 @@ import org.joml.Vector4f;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.OptionalDouble;
@@ -323,6 +325,23 @@ public class SpaceRenderingManager {
                 matrices.pop();
                 matrix4fStack.popMatrix();
             }
+        }
+    }
+
+    public static void assignIrisPipeline() {
+        try {
+            String irisApiPackage = "net.irisshaders.iris.api.v0.";
+
+            Class<?> irisApiClass = Class.forName(irisApiPackage + "IrisApi");
+            Object INSTANCE = irisApiClass.getMethod("getInstance").invoke(null);
+
+            Class<?> irisProgramClass = Class.forName(irisApiPackage + "IrisProgram");
+            Enum<?> SKY_BASIC = Enum.valueOf(irisProgramClass.asSubclass(Enum.class), "SKY_BASIC");
+
+            Method assignPipeline = irisApiClass.getMethod("assignPipeline", RenderPipeline.class, irisProgramClass);
+            assignPipeline.invoke(INSTANCE, pipeline, SKY_BASIC);
+        } catch (Exception ignored) {
+            SpyglassAstronomyClient.LOGGER.error("Failed to assign pipeline. Shader compatibility may be broken");
         }
     }
 

--- a/src/main/java/com/nettakrim/spyglass_astronomy/SpyglassAstronomyClient.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/SpyglassAstronomyClient.java
@@ -1,5 +1,6 @@
 package com.nettakrim.spyglass_astronomy;
 
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.nettakrim.spyglass_astronomy.commands.admin_subcommands.StarCountCommand;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -19,6 +20,8 @@ import org.slf4j.LoggerFactory;
 import com.nettakrim.spyglass_astronomy.OrbitingBody.OrbitingBodyType;
 import com.nettakrim.spyglass_astronomy.commands.SpyglassAstronomyCommands;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 
 import net.minecraft.util.math.MathHelper;
@@ -77,6 +80,10 @@ public class SpyglassAstronomyClient implements ClientModInitializer {
         ClientTickEvents.END_CLIENT_TICK.register(client -> update());
 
         spyglassImprovementsIsLoaded = FabricLoader.getInstance().isModLoaded("spyglass-improvements");
+
+        if (FabricLoader.getInstance().isModLoaded("iris")) {
+            SpaceRenderingManager.assignIrisPipeline();
+        }
 	}
 
     public static void saveSpace() {


### PR DESCRIPTION
In 1.21.5+, Iris no longer renders Spyglass Astronomy's custom sky, as the `RenderPipeline` needs to be explicitly assigned in their API.
This pull request adds basic compatibility with Iris shaders by doing just that.

Fixes https://github.com/Nettakrim/Spyglass-Astronomy/issues/51