### PR TITLE
[bump] Update actions/upload-artifact to v4 as v2 is deprecated.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '21' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/libs/


### PR DESCRIPTION
Updated "build" action to use actions/upload-artifact@v4, as v2 is deprecated and no longer usable. This should fix the build action failing to run.

Happy holidays!