### PR TITLE
Add Iris/Oculus shader compatibility (WorldRenderEvents.LAST)

### DIFF
--- a/src/main/java/com/nettakrim/spyglass_astronomy/Orbit.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/Orbit.java
@@ -3,7 +3,7 @@ package com.nettakrim.spyglass_astronomy;
 import org.joml.Vector3f;
 
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
+import org.joml.Quaternionf;
 
 public class Orbit {
     public final float period;
@@ -55,9 +55,9 @@ public class Orbit {
     }
 
     public void rotateLocalPosition(Vector3f vector) {
-        vector.rotate(RotationAxis.POSITIVE_X.rotationDegrees(inclination));
-        vector.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(ascension));
-        vector.rotate(RotationAxis.POSITIVE_Z.rotationDegrees(rotation));
+        vector.rotate(new Quaternionf().rotationX((float)Math.toRadians(inclination)));
+        vector.rotate(new Quaternionf().rotationY((float)Math.toRadians(ascension)));
+        vector.rotate(new Quaternionf().rotationZ((float)Math.toRadians(rotation)));
     }
 
     public Vector3f getLastRotatedPosition() {

--- a/src/main/java/com/nettakrim/spyglass_astronomy/OrbitingBody.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/OrbitingBody.java
@@ -7,7 +7,6 @@ import org.joml.Vector3f;
 
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
 
 public class OrbitingBody {
     public final Orbit orbit;
@@ -87,7 +86,7 @@ public class OrbitingBody {
             axis1.normalize();
 
             axis2 = new Vector3f(axis1);
-            axis2.rotate(RotationAxis.of(position).rotationDegrees(90));
+            axis2.rotate(new Quaternionf().rotationAxis((float)Math.toRadians(90), position));
         
             float sizeScale = MathHelper.clamp(
                 (size/visibilityScale)*3,
@@ -115,7 +114,7 @@ public class OrbitingBody {
         }
         currentAlpha = (int)(alphaRaw*255);
 
-        Quaternionf rotation = RotationAxis.of(position).rotationDegrees(angle);
+        Quaternionf rotation = new Quaternionf().rotationAxis((float)Math.toRadians(angle), position);
         Vector3f rotatedAxis1 = new Vector3f(axis1);
         Vector3f rotatedAxis2 = new Vector3f(axis2);
         rotatedAxis1.rotate(rotation);
@@ -146,7 +145,7 @@ public class OrbitingBody {
                     //ring
                     float ringOut = 1.3f;
                     float ringIn = 0.9f;
-                    Quaternionf slowOppositeRotation = RotationAxis.of(position).rotationDegrees(-angle / 2);
+                    Quaternionf slowOppositeRotation = new Quaternionf().rotationAxis((float)Math.toRadians(-angle / 2), position);
                     Vector3f in1 = new Vector3f(axis1);
                     in1.rotate(slowOppositeRotation);
                     Vector3f out1 = new Vector3f(in1);

--- a/src/main/java/com/nettakrim/spyglass_astronomy/SpaceRenderingManager.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/SpaceRenderingManager.java
@@ -13,9 +13,9 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
 
 import org.joml.Matrix4f;
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Scanner;
+import java.lang.reflect.Method;
 
 public class SpaceRenderingManager {
     private final VertexBuffer starsBuffer = new VertexBuffer(Usage.STATIC);
@@ -42,6 +43,47 @@ public class SpaceRenderingManager {
     private final BufferBuilder planetsBufferBuilder = Tessellator.getInstance().getBuffer();
 
     private static float heightScale = 1;
+
+    private static Boolean shaderModLoaded = null;
+
+    private static boolean isShaderModLoaded() {
+        if (shaderModLoaded == null) {
+            try {
+                Class<?> loaderClass = Class.forName("net.fabricmc.loader.api.FabricLoader");
+                Object loader = loaderClass.getMethod("getInstance").invoke(null);
+                boolean iris = (boolean) loaderClass.getMethod("isModLoaded", String.class).invoke(loader, "iris");
+                boolean oculus = (boolean) loaderClass.getMethod("isModLoaded", String.class).invoke(loader, "oculus");
+                shaderModLoaded = iris || oculus;
+            } catch (Exception e) {
+                shaderModLoaded = false;
+            }
+        }
+        return shaderModLoaded;
+    }
+
+    public static boolean isShadersActive() {
+        if (!isShaderModLoaded()) return false;
+        try {
+            Class<?> apiClass = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+            Object api = apiClass.getMethod("getInstance").invoke(null);
+            Method m = apiClass.getMethod("isShaderPackInUse");
+            return (boolean) m.invoke(api);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public static boolean isRenderingShadowPass() {
+        if (!isShaderModLoaded()) return false;
+        try {
+            Class<?> apiClass = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+            Object api = apiClass.getMethod("getInstance").invoke(null);
+            Method m = apiClass.getMethod("isRenderingShadowPass");
+            return (boolean) m.invoke(api);
+        } catch (Exception e) {
+            return false;
+        }
+    }
 
     public static boolean constellationsVisible;
 	public static boolean starsVisible;
@@ -205,9 +247,9 @@ public class SpaceRenderingManager {
         if (starVisibility > 0) {
             matrices.pop();
             matrices.push();
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0f));
-            matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(SpyglassAstronomyClient.getStarAngle()));
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(45f));
+            matrices.multiply(new Quaternionf().rotationY((float) Math.toRadians(-90.0)));
+            matrices.multiply(new Quaternionf().rotationX((float) Math.toRadians(SpyglassAstronomyClient.getStarAngle())));
+            matrices.multiply(new Quaternionf().rotationY((float) Math.toRadians(45.0)));
             float colorScale = starVisibility+Math.min(heightScale, 0.5f);
             RenderSystem.setShaderColor(colorScale, colorScale, colorScale, starVisibility);
             BackgroundRenderer.clearFog();
@@ -232,7 +274,7 @@ public class SpaceRenderingManager {
             if (orbitingBodiesVisible) {
                 matrices.pop();
                 matrices.push();
-                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(SpyglassAstronomyClient.getPositionInOrbit(360f)*(1-1/SpyglassAstronomyClient.earthOrbit.period)+180));
+                matrices.multiply(new Quaternionf().rotationZ((float) Math.toRadians(SpyglassAstronomyClient.getPositionInOrbit(360f)*(1-1/SpyglassAstronomyClient.earthOrbit.period)+180)));
 
                 planetsBuffer.bind();
                 planetsBuffer.draw(matrices.peek().getPositionMatrix(), projectionMatrix, GameRenderer.getPositionColorProgram());

--- a/src/main/java/com/nettakrim/spyglass_astronomy/SpyglassAstronomyClient.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/SpyglassAstronomyClient.java
@@ -3,7 +3,9 @@ package com.nettakrim.spyglass_astronomy;
 import com.nettakrim.spyglass_astronomy.commands.admin_subcommands.StarCountCommand;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.loader.api.FabricLoader;
+import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.item.Items;
@@ -22,7 +24,7 @@ import com.nettakrim.spyglass_astronomy.commands.SpyglassAstronomyCommands;
 import java.util.ArrayList;
 
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
+import org.joml.Quaternionf;
 
 public class SpyglassAstronomyClient implements ClientModInitializer {
 	// This logger is used to write text to the console and the log file.
@@ -75,6 +77,19 @@ public class SpyglassAstronomyClient implements ClientModInitializer {
         SpyglassAstronomyCommands.initialize();
 
         ClientTickEvents.END_CLIENT_TICK.register(client -> update());
+
+        // When a shader pack is active, render after Iris's composite passes so vertex colors
+        // reach the output framebuffer directly instead of going through the deferred GBuffer pipeline.
+        WorldRenderEvents.LAST.register(context -> {
+            if (!SpaceRenderingManager.isShadersActive()) return;
+            if (SpaceRenderingManager.isRenderingShadowPass()) return;
+            if (spaceRenderingManager == null) return;
+            net.minecraft.client.util.math.MatrixStack matrices = context.matrixStack();
+            matrices.push();
+            spaceRenderingManager.Render(matrices, context.projectionMatrix(), context.tickDelta(), context.camera(), false, () -> {});
+            matrices.pop();
+            RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+        });
 
         spyglassImprovementsIsLoaded = FabricLoader.getInstance().isModLoaded("spyglass-improvements");
 	}
@@ -598,13 +613,13 @@ public class SpyglassAstronomyClient implements ClientModInitializer {
     }
 
     public static void rotateVectorToStarRotation(Vector3f vector) {
-        vector.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(90.0f));
-        vector.rotate(RotationAxis.POSITIVE_X.rotationDegrees(getStarAngle()*-1));
-        vector.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(-45f));
+        vector.rotate(new Quaternionf().rotationY((float)Math.toRadians(90.0)));
+        vector.rotate(new Quaternionf().rotationX((float)Math.toRadians(getStarAngle()*-1)));
+        vector.rotate(new Quaternionf().rotationY((float)Math.toRadians(-45.0)));
     }
 
     public static void rotateVectorToOrbitingBodyRotation(Vector3f vector) {
-        vector.rotate(RotationAxis.POSITIVE_Z.rotationDegrees(SpyglassAstronomyClient.getPositionInOrbit(-360f)*(1-1/SpyglassAstronomyClient.earthOrbit.period)+180));
+        vector.rotate(new Quaternionf().rotationZ((float)Math.toRadians(SpyglassAstronomyClient.getPositionInOrbit(-360f)*(1-1/SpyglassAstronomyClient.earthOrbit.period)+180)));
     }
 
     public static Star getNearestStar(float x, float y, float z) {

--- a/src/main/java/com/nettakrim/spyglass_astronomy/commands/InfoCommand.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/commands/InfoCommand.java
@@ -20,7 +20,7 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
+import org.joml.Quaternionf;
 
 public class InfoCommand implements Command<FabricClientCommandSource> {
 
@@ -222,9 +222,9 @@ public class InfoCommand implements Command<FabricClientCommandSource> {
 
     private static void staticVisibilityInfo(MutableText text, Vector3f position, int[] flags) {
         Vector3f pos = new Vector3f(position);
-        pos.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(45f));
-        pos.rotate(RotationAxis.POSITIVE_X.rotationDegrees(SpyglassAstronomyClient.getStarAngle()));
-        pos.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0f));
+        pos.rotate(new Quaternionf().rotationY((float)Math.toRadians(45.0)));
+        pos.rotate(new Quaternionf().rotationX((float)Math.toRadians(SpyglassAstronomyClient.getStarAngle())));
+        pos.rotate(new Quaternionf().rotationY((float)Math.toRadians(-90.0)));
 
         float yaw = (float)(Math.atan2(pos.x, pos.z)*-180d/Math.PI);
         float angle = (float)(Math.atan2(Math.sqrt(pos.x * pos.x + pos.z * pos.z), pos.y)*180d/Math.PI)-90;
@@ -233,9 +233,9 @@ public class InfoCommand implements Command<FabricClientCommandSource> {
 
         if (SpyglassAstronomyClient.knowledge.starKnowledgeAtleast(Level.ADEPT, flags)) {
             pos = new Vector3f(position);
-            pos.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(45f));
-            pos.rotate(RotationAxis.POSITIVE_X.rotationDegrees(SpyglassAstronomyClient.starAngleMultiplier*(0.75f/SpyglassAstronomyClient.earthOrbit.period)));
-            pos.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0f));
+            pos.rotate(new Quaternionf().rotationY((float)Math.toRadians(45.0)));
+            pos.rotate(new Quaternionf().rotationX((float)Math.toRadians(SpyglassAstronomyClient.starAngleMultiplier*(0.75f/SpyglassAstronomyClient.earthOrbit.period))));
+            pos.rotate(new Quaternionf().rotationY((float)Math.toRadians(-90.0)));
             if (MathHelper.abs(pos.z) < 0.9f) {
                 float referenceYaw = (float)(Math.atan2(pos.x, pos.z)*-180d/Math.PI);
                 angle = (float)(Math.atan2(Math.sqrt(pos.x * pos.x + pos.z * pos.z), pos.y)*180d/Math.PI)-90;
@@ -290,7 +290,7 @@ public class InfoCommand implements Command<FabricClientCommandSource> {
                 text.append(translate("orbit.distance", prettyFloat(MathHelper.sqrt(sqrDistance)/SpyglassAstronomyClient.earthOrbit.semiMajorAxis)));
 
                 pos.normalize();
-                pos.rotate(RotationAxis.POSITIVE_Z.rotationDegrees((SpyglassAstronomyClient.getPositionInOrbit(360f)*(1-1/SpyglassAstronomyClient.earthOrbit.period)+180)));
+                pos.rotate(new Quaternionf().rotationZ((float)Math.toRadians(SpyglassAstronomyClient.getPositionInOrbit(360f)*(1-1/SpyglassAstronomyClient.earthOrbit.period)+180)));
 
                 float yaw = (float)(Math.atan2(pos.x, pos.z)*-180d/Math.PI);
                 float angle = (float)(Math.atan2(Math.sqrt(pos.x * pos.x + pos.z * pos.z), pos.y)*180d/Math.PI)-90;

--- a/src/main/java/com/nettakrim/spyglass_astronomy/mixin/WorldRendererMixin.java
+++ b/src/main/java/com/nettakrim/spyglass_astronomy/mixin/WorldRendererMixin.java
@@ -3,6 +3,7 @@ package com.nettakrim.spyglass_astronomy.mixin;
 import com.nettakrim.spyglass_astronomy.SpaceRenderingManager;
 import com.nettakrim.spyglass_astronomy.SpyglassAstronomyClient;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gl.ShaderProgram;
 import net.minecraft.client.gl.VertexBuffer;
 import net.minecraft.client.render.Camera;
@@ -17,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.Shadow;
 
-@Mixin(WorldRenderer.class)
+@Mixin(value = WorldRenderer.class, priority = 2000)
 public class WorldRendererMixin {
     @Shadow private int ticks;
 
@@ -31,13 +32,18 @@ public class WorldRendererMixin {
         }
     }
 
+    // Vanilla path (no shaders): inject at the original point
     @Inject(
         method = "renderSky(Lnet/minecraft/client/util/math/MatrixStack;Lorg/joml/Matrix4f;FLnet/minecraft/client/render/Camera;ZLjava/lang/Runnable;)V",
         at = @At(value = "INVOKE", ordinal = 4, target="Lcom/mojang/blaze3d/systems/RenderSystem;setShaderColor(FFFF)V")
     )
     public void renderSky(MatrixStack matrices, Matrix4f projectionMatrix, float tickDelta, Camera camera, boolean bl, Runnable runnable, CallbackInfo ci) {
+        if (SpaceRenderingManager.isShadersActive()) return;
         SpyglassAstronomyClient.spaceRenderingManager.Render(matrices, projectionMatrix, tickDelta, camera, bl, runnable);
     }
+
+    // Shader path is handled by WorldRenderEvents.LAST in SpyglassAstronomyClient,
+    // which fires after Iris's composite passes so vertex colors reach the output framebuffer directly.
 
     @Inject(at = @At("HEAD"), method = "tick")
     private void updateStars(CallbackInfo ci) {


### PR DESCRIPTION
**Problem**

When using shader packs with a deferred rendering pipeline (Complementary, SEUS Renewed, etc.), the mod's stars, planets and constellations were completely invisible. Simpler shader packs that don't use a GBuffer are unaffected..

**Root cause**

Iris routes all geometry through gbuffers_* programs before composite passes and tone mapping. Custom geometry rendered during WorldRenderer.renderSky() ends up in the GBuffer and gets multiplied by near-zero nighttime ambient lighting, zeroing out vertex colors before they reach the screen.

**Fix**

Moved the shader rendering path to WorldRenderEvents.LAST, which fires after Iris's composite passes and writes directly to the output framebuffer. Vertex colors are preserved as-is. The vanilla (no-shader) path is unchanged.

Shader detection uses reflection on net.irisshaders.iris.api.v0.IrisApi ; no hard compile-time dependency on Iris.

<img width="2560" height="1369" alt="2026-04-26_00 25 35" src="https://github.com/user-attachments/assets/3c425cdc-1f3b-45ce-ad78-b2a06dd3727d" />
<img width="2560" height="1369" alt="2026-04-26_00 25 15" src="https://github.com/user-attachments/assets/11b5e396-5cbf-4ad4-8a37-bb987385f2b5" />


**_Also experimental try_**

Replaced RotationAxis with direct JOML Quaternionf calls. Under Sinytra Connector, Loom remaps RotationAxis to com.mojang.math.Axis which lacks rotationDegrees() : this may cause a NoSuchMethodError at runtime in some configurations.

**Known limitation**

Because rendering happens after the shader's composite passes, stars don't interact with shader effects (no bloom, no atmospheric depth) and render on top of clouds rather than behind them near the horizon. It is particularly obvious if you're using DIstant Horizon, for Instance, as shown here.
<img width="2560" height="1369" alt="2026-04-26_00 28 10" src="https://github.com/user-attachments/assets/a47c9204-f9ba-4be6-9d09-666a22e826cb" />
